### PR TITLE
swap mktime for timegm, mktime uses local timegm/utc .

### DIFF
--- a/timehash/__init__.py
+++ b/timehash/__init__.py
@@ -29,6 +29,7 @@
 """
 import time
 import datetime
+import calendar
 
 __base32 = '01abcdef'
 __before = 'f01abcde'
@@ -167,7 +168,7 @@ def encode_from_datetime(datetime_object, precision=10):
 
     For alternate ways to do datetime conversions, see also: http://stackoverflow.com/questions/6999726/how-can-i-convert-a-datetime-object-to-milliseconds-since-epoch-unix-time-in-p
     """
-    milliseconds = time.mktime(datetime_object.timetuple())
+    milliseconds = calendar.timegm(datetime_object.timetuple())
     return encode(milliseconds, precision)
 
 


### PR DESCRIPTION
Since the Time Hash uses UTC/unix epoch time, it's probably best that your time_object, which is "naive" to timezones, expect to use GMT, as everything the script does is milliseconds from epoch which is UTC/GMT.